### PR TITLE
如果分析文件路径里，包含root文件名，则不会正常生成分析结果

### DIFF
--- a/trunk/common/filedepend.cpp
+++ b/trunk/common/filedepend.cpp
@@ -663,7 +663,7 @@ CCodeFile* CFileDependTable::FindShortestPath(const std::vector<CCodeFile*>& vec
 
 bool CFileDependTable::CreateFileDependTree(const std::vector<std::string> &paths, const std::vector<std::string> &includePaths, const std::vector<std::string>& excludesPaths)
 {
-	m_pRoot = new CFolder("root");
+	m_pRoot = new CFolder("");
 	std::vector<std::string>::const_iterator iterBegin = paths.begin();
 	std::vector<std::string>::const_iterator iterEnd = paths.end();
 	for (std::vector<std::string>::const_iterator iter = iterBegin; iter != iterEnd; iter++)
@@ -921,7 +921,7 @@ std::string CFileBase::GetFullPath()
 {
 	std::string sFullPath = GetName();
 	CFileBase* pFile = GetParent();
-	while (pFile && pFile->GetName() != "root")
+	while (pFile)
 	{
 		sFullPath = pFile->GetName() + "/" + sFullPath;
 		pFile = pFile->GetParent();


### PR DESCRIPTION
#### *如下目录装不会生成分析结果*
```
cd /tmp/root/TscanCode/samples/cpp
/tmp/root/TscanCode/trunk/tscancode --enable=all --debug -j1 --xml $PWD
```
