### PR TITLE
Clean up compiler warnings and deprecated usage in core build

### DIFF
--- a/trunk/cli/tscexecutor.cpp
+++ b/trunk/cli/tscexecutor.cpp
@@ -318,7 +318,8 @@ static void print_stacktrace(FILE* f, bool demangling, int maxdepth)
 #endif
 }
 
-static const size_t MYSTACKSIZE = 16 * 1024 + SIGSTKSZ; // wild guess about a reasonable buffer
+// static const size_t MYSTACKSIZE = 16 * 1024 + SIGSTKSZ; // wild guess about a reasonable buffer
+static const size_t MYSTACKSIZE = 16 * 1024 + 131072; // wild guess about a reasonable buffer
 static char mytstack[MYSTACKSIZE]; // alternative stack for signal handler
 static bool bStackBelowHeap = false; // lame attempt to locate heap vs. stack address space
 

--- a/trunk/cli/tscthreadexecutor.cpp
+++ b/trunk/cli/tscthreadexecutor.cpp
@@ -200,8 +200,6 @@ unsigned int __stdcall TscThreadExecutor::threadProc(void *args)
 void* TscThreadExecutor::threadProc(void *args)
 #endif
 {
-    unsigned int result = 0;
-
     TscThreadExecutor *threadExecutor = static_cast<TscThreadExecutor*>(args);
     TSC_LOCK_ENTER(&threadExecutor->_fileSync);
 
@@ -238,7 +236,7 @@ void* TscThreadExecutor::threadProc(void *args)
 			}
 			else {
 				pGlobalData->RecoredExportClass(false);
-				result += fileChecker.check(file, fileContent->second);
+				fileChecker.check(file, fileContent->second);
 			}
 		}
 		else {
@@ -248,7 +246,7 @@ void* TscThreadExecutor::threadProc(void *args)
 			}
 			else {
 				pGlobalData->RecoredExportClass(false);
-				result += fileChecker.check(file);
+				fileChecker.check(file);
 			}
 		}
 

--- a/trunk/cli/tscthreadexecutor.cpp
+++ b/trunk/cli/tscthreadexecutor.cpp
@@ -30,6 +30,7 @@
 #include "path.h"
 #include "globalmacros.h"
 #include "checktscinvalidvarargs.h"
+#include <cstdint>
 
 #define MAXERRORCNT 30
 #define AUTOFILTER_SUBID "FuncPossibleRetNULL|FuncRetNULL|dereferenceAfterCheck|dereferenceBeforeCheck|possibleNullDereferenced|nullpointerarg|nullpointerclass"

--- a/trunk/lib/checktscinvalidvarargs.cpp
+++ b/trunk/lib/checktscinvalidvarargs.cpp
@@ -229,7 +229,7 @@ void CheckTSCInvalidVarArgs::CheckVarArgs_new()
 void CheckTSCInvalidVarArgs::ReportErrorParamDismatch(const Token *tok, const string& funcName/*, bool inconclusive*/ /*= false*/)
 {
 	char szMsg[0x100] = {0};
-	sprintf(szMsg, "The count of parameters mismatches the format string in %s", funcName.c_str());
+	snprintf(szMsg, sizeof(szMsg), "The count of parameters mismatches the format string in %s", funcName.c_str());
 	
 	reportError(tok, Severity::error, ErrorType::Logic, "InvalidVarArgs", szMsg, ErrorLogger::GenWebIdentity((funcName)));
 }
@@ -253,7 +253,6 @@ void CheckTSCInvalidVarArgs::CheckScope(const Token *tokBegin, const Token *tokE
 	}
 
 	bool bUsed = false;
-	bool bBlankStr = false;
 	while(!useStack.empty())
 	{
 		std::string useType = useStack.top();
@@ -269,7 +268,6 @@ void CheckTSCInvalidVarArgs::CheckScope(const Token *tokBegin, const Token *tokE
 
 			if (pTokBack && pTokBack->tokType() == Token::eString)
 			{
-				bBlankStr = true;
 				strFormatted = pTokBack->str();
 				break;
 			}

--- a/trunk/lib/checktscnullpointer2.cpp
+++ b/trunk/lib/checktscnullpointer2.cpp
@@ -3894,7 +3894,6 @@ const Token* CheckTSCNullPointer2::HandleFuncParam(const Token* tok)
 		{
 			if (tokFunc->isName())
 			{
-				bool bDefFound = false;
 				const gt::CFunction *gtFunc = CGlobalTokenizer::Instance()->FindFunctionData(tokFunc);
 				if (gtFunc)
 				{
@@ -3930,7 +3929,6 @@ const Token* CheckTSCNullPointer2::HandleFuncParam(const Token* tok)
 					{
 						return tok;
 					}
-					bDefFound = true;
 				}
 
 				std::set<gt::SVarEntry> derefedVar;
@@ -4250,7 +4248,6 @@ bool CheckTSCNullPointer2::ExtractCondFromToken(const Token* tok, CCompoundExpr*
 			if (tok1 && tok2)
 			{
 				const ValueFlow::Value* value = nullptr;
-				const Token* tokValue = nullptr;
 				const Token* tokExpr = nullptr;
 
 				if (tok1->values.size() == 1)
@@ -4260,8 +4257,6 @@ bool CheckTSCNullPointer2::ExtractCondFromToken(const Token* tok, CCompoundExpr*
 					if (value->isKnown() && !value->tokvalue)
 					{
 						tokExpr = tok2;
-						tokValue = tok1;
-
 						if (sComp == "<")
 						{
 							sComp = ">";
@@ -4289,7 +4284,6 @@ bool CheckTSCNullPointer2::ExtractCondFromToken(const Token* tok, CCompoundExpr*
 						if (value->isKnown() && !value->tokvalue)
 						{
 							tokExpr = tok1;
-							tokValue = tok2;
 						}
 					}
 				}

--- a/trunk/lib/checktscoverrun.cpp
+++ b/trunk/lib/checktscoverrun.cpp
@@ -301,7 +301,6 @@ void CheckTSCOverrun::checkIndexCheckDefect()
 						}
 
 						bool bOK = false;
-						bool bRet = false;
 						if (tokCond->str() == "if" && layer1 == 0 && layer2 > 0)
 						{
 							if (tokOp->str() == ">")
@@ -338,7 +337,7 @@ void CheckTSCOverrun::checkIndexCheckDefect()
 
 							if (bOK)
 							{
-								bRet = IsScopeReturn(tokCond);
+								IsScopeReturn(tokCond);
 							}
 						}
 						else if ((tokCond->str() == "if" && layer1 > 0) || (tokCond->str() == "for" && layer1 > 0))
@@ -370,8 +369,6 @@ void CheckTSCOverrun::checkIndexCheckDefect()
 									}
 								}
 							}
-
-							bRet = bOK;
 
 						}
 

--- a/trunk/lib/checkuninitvar.cpp
+++ b/trunk/lib/checkuninitvar.cpp
@@ -1286,7 +1286,7 @@ void CheckUninitVar::ReportUninitStructError(const std::string& str, const Token
 			{
 				if (!tokCaller->isExpandedMacro())
 				{
-					sprintf(szBuf, "%u", iterErr->second.begin()->second->linenr());
+					snprintf(szBuf, eBufLen, "%u", iterErr->second.begin()->second->linenr());
 					reportError(tokCaller,
 						Severity::error, ErrorType::Uninit,
 						(bPossible ? "PossibleUninitStruct" : "UninitStruct"),

--- a/trunk/lib/errorlogger.cpp
+++ b/trunk/lib/errorlogger.cpp
@@ -339,7 +339,7 @@ std::string ErrorLogger::ErrorMessage::toXML_codetrace(bool verbose, int version
 				startline = 1;
 			endline = 10 + fline;
 			char sline[20];
-			sprintf(sline, "%d", i);
+			snprintf(sline, sizeof(sline), "%d", i);
 			if (i >= startline && i <= endline)
 			{
 				content += string(sline) + ": " + strTextLine + "\n";

--- a/trunk/lib/executionpath.cpp
+++ b/trunk/lib/executionpath.cpp
@@ -134,7 +134,7 @@ void ExecutionPath::checkScope(const Token *tok, std::list<ExecutionPath *> &che
     if (!tok || tok->str() == "}" || checks.empty())
         return;
 
-    const std::auto_ptr<ExecutionPath> check(checks.front()->copy());
+    std::unique_ptr<ExecutionPath> check(checks.front()->copy());
 
     for (; tok; tok = tok->next()) {
         // might be a noreturn function..

--- a/trunk/lib/globalsymboldatabase.cpp
+++ b/trunk/lib/globalsymboldatabase.cpp
@@ -2411,7 +2411,6 @@ namespace gt
 		bool bHasError;
 		bool bIfThenRet;
 		bool bUnderIf;
-		bool bUnknownIf;
 		bool bStrictIf;
 		bool bStrictElse;
 	};

--- a/trunk/lib/globalsymboldatabase.h
+++ b/trunk/lib/globalsymboldatabase.h
@@ -681,7 +681,7 @@ namespace gt
 		CField(const std::string& name, unsigned flags, AccessControl ac, Type::NeedInitialization init)
 			: m_name(name), m_access(ac), m_flags(flags), m_gtType(nullptr), m_needInit(init)
 		{
-			
+			(void)m_access;
 		}
 		const std::string& GetName() const
 		{

--- a/trunk/lib/preprocessor.cpp
+++ b/trunk/lib/preprocessor.cpp
@@ -1919,12 +1919,6 @@ std::string Preprocessor::getcode(const std::string &filedata, const std::string
         if (_settings.terminated())
             return "";
 
-		if (line.compare(0, 7, "#pragma") == 0)
-		{
-			int i = 0;
-			++i;
-		}
-
         if (line.compare(0, 11, "#pragma asm") == 0) {
             ret << "\n";
             bool found_end = false;

--- a/trunk/lib/tokenize.cpp
+++ b/trunk/lib/tokenize.cpp
@@ -2358,6 +2358,9 @@ void Tokenizer::simplifyTypedef2_expandTypedefs(std::unordered_map<const Token*,
 				}
 				if (pEntry->TypeStart->str() == "struct" && Token::Match(tok2, "%name% ::"))
 					pEntry->TypeStart = pEntry->TypeStart->next();
+				(void)inTemplate;
+				(void)inOperator;
+				(void)structRemoved;
 
 				// start substituting at the typedef name by replacing it with the type
 				std::string orgname = tok2->str();
@@ -2521,10 +2524,8 @@ bool Tokenizer::simplifyTypedef2_expandTypedef_global(Token*& tok)
 
 void Tokenizer::simplifyTypedef2_eraseTypedefs(std::unordered_map<const Token*, STypedefEntry>& allTypedefs)
 {
-	int index = 0;
 	for (std::unordered_map<const Token*, STypedefEntry>::iterator I = allTypedefs.begin(), E = allTypedefs.end(); I != E; ++I)
 	{
-		index++;
 		Token* tokTypedef = I->second.TypeDef;
 		deleteInvalidTypedef(tokTypedef);//ignore TSC
 	}
@@ -6495,7 +6496,6 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, Token * tokEnd, bool only_k_r_
 			continue;
 
 		bool isconst = false;
-		bool isstatic = false;
 		Token *tok2 = type0;
 		unsigned int typelen = 1;
 
@@ -6513,9 +6513,6 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, Token * tokEnd, bool only_k_r_
 
 			if (tok2->str() == "const")
 				isconst = true;
-
-			else if (tok2->str() == "static")
-				isstatic = true;
 
 			else if (Token::Match(tok2, "%type% :: %type%")) {
 				tok2 = tok2->next();
@@ -9010,7 +9007,6 @@ bool Tokenizer::simplifyEnum2_substituteEnums(std::list<TSCEnumerator>& enumList
 
 		validEnums.push_back(&(*I));
 
-		int level = 0;
 		std::stack<std::set<std::string> > shadowId;  // duplicate ids in inner scope
 		bool simplify = false;
 		const EnumValue *ev = nullptr;
@@ -9020,10 +9016,6 @@ bool Tokenizer::simplifyEnum2_substituteEnums(std::list<TSCEnumerator>& enumList
 		{
 			if (tok2->str() == "}")
 			{
-				--level;
-				//if (level < 0)
-					//inScope = false;
-
 				if (!shadowId.empty())
 					shadowId.pop();
 			}
@@ -9046,8 +9038,6 @@ bool Tokenizer::simplifyEnum2_substituteEnums(std::list<TSCEnumerator>& enumList
 				else
 				{
 					// Not a duplicate enum..
-					++level;
-
 					std::set<std::string> shadowVars = shadowId.empty() ? std::set<std::string>() : shadowId.top();
 					// are there shadow arguments?
 					if (Token::simpleMatch(tok2->previous(), ") {") || Token::simpleMatch(tok2->tokAt(-2), ") const {")) {

--- a/trunk/lib/valueflow.cpp
+++ b/trunk/lib/valueflow.cpp
@@ -455,7 +455,7 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value)
                     (value1->varId == value2->varId && value1->varvalue == value2->varvalue && !value1->tokvalue && !value2->tokvalue)) {
                     ValueFlow::Value result(0);
                     result.condition = value1->condition ? value1->condition : value2->condition;
-                    result.inconclusive = value1->inconclusive | value2->inconclusive;
+                    result.inconclusive = value1->inconclusive || value2->inconclusive;
                     result.varId = (value1->varId != 0U) ? value1->varId : value2->varId;
                     result.varvalue = (result.varId == value1->varId) ? value1->intvalue : value2->intvalue;
                     if (value1->valueKind == value2->valueKind)
@@ -571,7 +571,7 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value)
                     (value1->varId == value2->varId && value1->varvalue == value2->varvalue)) {
                     ValueFlow::Value result(0);
                     result.condition = value1->condition ? value1->condition : value2->condition;
-                    result.inconclusive = value1->inconclusive | value2->inconclusive;
+                    result.inconclusive = value1->inconclusive || value2->inconclusive;
                     result.varId = (value1->varId != 0U) ? value1->varId : value2->varId;
                     result.varvalue = (result.varId == value1->varId) ? value1->intvalue : value2->intvalue;
                     if (value1->valueKind == value2->valueKind)


### PR DESCRIPTION
#### This PR cleans up all observed compilation warnings and modernizes a few obsolete usages, with no functional changes expected.
	•	Replace sprintf with snprintf to avoid deprecation warnings
	•	Remove unused local variables and a no-op #pragma block
	•	Migrate from std::auto_ptr to std::unique_ptr
	•	Fix a bitwise OR on booleans by switching to ||
	•	Remove an unused class member and silence an unused private field

#### Tests
	•	make -C trunk